### PR TITLE
fix missing tempo for swapped hotkeys

### DIFF
--- a/get_emit.ipynb
+++ b/get_emit.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,20 +120,27 @@
     "    tempos = []\n",
     "    curr_block = END_BLOCK\n",
     "    while curr_block > START_BLOCK:\n",
-    "        if i == 0:\n",
-    "            # If the start hotkey, check for swap happened\n",
-    "            zero_key_stake = sub.query_subtensor(\"Stake\", curr_block, params=[curr_hk, ZERO_KEY])\n",
-    "            if zero_key_stake.value > 0:\n",
-    "                print(f\"Hotkey {curr_hk} swapped before block {curr_block}\")\n",
-    "                break\n",
-    "\n",
     "        # Get last emission drain\n",
     "        last_emission_drain = sub.query_subtensor(\"LastHotkeyEmissionDrain\", curr_block, params=[curr_hk])\n",
     "        if not last_emission_drain:\n",
     "            print(f\"No last emission drain found at block {curr_block}\")\n",
     "            break\n",
-    "        tempos.append(last_emission_drain.value)\n",
+    "\n",
+    "        if i == 0:\n",
+    "            # If the start hotkey, check for swap happened\n",
+    "            zero_key_stake = sub.query_subtensor(\"Stake\", curr_block, params=[curr_hk, ZERO_KEY])\n",
+    "            if zero_key_stake.value > 0:\n",
+    "                print(f\"Hotkey {curr_hk} swapped before block {curr_block}\")\n",
+    "                # Hotkey swapped already, skip\n",
+    "            else:\n",
+    "                tempos.append(last_emission_drain.value)\n",
+    "                print(\"Adding tempo for start hotkey\", last_emission_drain.value)\n",
+    "        else:\n",
+    "            tempos.append(last_emission_drain.value)\n",
+    "\n",
     "        curr_block = last_emission_drain.value - 1\n",
+    "\n",
+    "        \n",
     "\n",
     "    filtered_tempos = [t for t in tempos if t > 0]\n",
     "   \n",
@@ -182,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
The current script misses any tempos that happened *before* the hotkey was swapped, which is not the intention.